### PR TITLE
Seurat slot deprecation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SpatialDecon
 Title: Deconvolution of mixed cells from spatial and/or bulk gene expression data
-Version: 1.13.2
+Version: 1.20.1
 Authors@R: c(person("Maddy", "Griswold", email = "mgriswold@nanostring.com", role = c("cre", "aut")),
              person("Patrick", "Danaher", email = "pdanaher@nanostring.com", role = c("aut")))
 Description: Using spatial or bulk gene expression data, estimates abundance of mixed cell types

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+Changes in version 1.20.1 (2025-12-22)
++ Bug fix in vignette Seurat creation
+
 Changes in version 1.13.2 (2023-12-28)
 + Compatibility with Seurat v5
 

--- a/vignettes/SpatialDecon_vignette.Rmd
+++ b/vignettes/SpatialDecon_vignette.Rmd
@@ -223,7 +223,7 @@ annots <- data.frame(cbind(cellType=as.character(Idents(seuratObject)),
 
 custom_mtx_seurat <- create_profile_matrix(mtx = Seurat::GetAssayData(object = seuratObject, 
                                                                       assay = "RNA", 
-                                                                      slot = "counts"), 
+                                                                      layer = "counts"), 
                                            cellAnnots = annots, 
                                            cellTypeCol = "cellType", 
                                            cellNameCol = "cellID", 


### PR DESCRIPTION
The use of slot was deprecated in Seurat5.3.0 that was released last week. This PR uses the layer variable. 

https://bioconductor.org/checkResults/3.22/bioc-LATEST/SpatialDecon/
ADO ticket #235877

Released Bioc version is 1.20.0. 

R CMD check SpatialDecon_1.20.1.tar.gz 
<img width="978" height="590" alt="image" src="https://github.com/user-attachments/assets/2ceb602c-b1dc-4fca-8081-38cb144d5dd4" />